### PR TITLE
Prevent Content-Length header from being copied

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"fmt"
 	"regexp"
+	"strings"
 	"net/http"
 	"io/ioutil"
 	"github.com/gosimple/conf"
@@ -62,8 +63,10 @@ func (f *Feed)ServeHTTP(respWriter http.ResponseWriter, req *http.Request) {
 	defer feedResp.Body.Close()
 	// copy headers
 	for field, values := range feedResp.Header {
-		for _, value := range values {
-			respWriter.Header().Add(field, value)
+		if (strings.ToLower(field) != "content-length") {
+			for _, value := range values {
+				respWriter.Header().Add(field, value)
+			}
 		}
 	}
 


### PR DESCRIPTION
When filters are active, the reported Content-Length is incorrect, leading to client errors.

Thanks for this project, exactly what I was looking for :)