### PR TITLE
Some more fixes for weird responses from servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 A simple proxy server for RSS feeds. RIP Yahoo Pipes.
 
 Supports serving protected feeds to clients without support
-for basic HTTP auth by injecting into the request. (Overcast on iOS)
+for basic HTTP auth by injecting into the request (Overcast on iOS).
 
-Supports filtering RSS feed items out of the respopnse to hide items,
+Supports filtering RSS feed items out of the response to hide items,
 matching regular expressions against specific fields on items.
 
-## Useage
+## Usage
 
   $ cp server.conf.dist server.conf
 

--- a/server.conf.dist
+++ b/server.conf.dist
@@ -10,6 +10,9 @@ ssl-key = server.key
 # prefix added to all feeds
 path-prefix = /feed
 
+# optionally specify a user-agent to be used for requests
+#user-agent = Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0
+
 # feed can be reached at /feed/giantbombcast-premium
 [giantbombcast-premium]
 feed = http://www.giantbomb.com/podcast-xml/premiumbombcast/
@@ -28,6 +31,9 @@ password = redacted
 # see https://github.com/google/re2/wiki/Syntax for details on the regex syntax avilable
 filter-field = Guid
 filter-exclude = http://.*/(\d+/){3}tr_
+
+# optionally, you may specify a user-agent - it will override the one specified above
+#user-agent = Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36
 
 [giantbomb-danswers]
 feed = http://www.giantbomb.com/podcast-xml/premium/

--- a/server.go
+++ b/server.go
@@ -60,7 +60,9 @@ func (f *Feed)ServeHTTP(respWriter http.ResponseWriter, req *http.Request) {
 
 	// request feed from remote
 	feedReq, _ := http.NewRequest("GET", f.url, nil)
-	feedReq.SetBasicAuth(f.username, f.password)
+	if (f.username != "") {
+		feedReq.SetBasicAuth(f.username, f.password)
+	}
 	if (f.agent != "") {
 		feedReq.Header.Set("User-Agent", f.agent)
 	}

--- a/server.go
+++ b/server.go
@@ -29,15 +29,17 @@ type Feed struct {
 	url string
 	username string
 	password string
+	agent string
 	filter *Filter
 }
 
-func NewFeed(name, url, username, password string) *Feed {
+func NewFeed(name, url, username, password, agent string) *Feed {
 	f := &Feed{
 		Name: name,
 		url: url,
 		username: username,
 		password: password,
+		agent: agent,
 		filter: nil,
 	}
 	echo("Registering handler for "+pathPrefix+name)
@@ -59,6 +61,9 @@ func (f *Feed)ServeHTTP(respWriter http.ResponseWriter, req *http.Request) {
 	// request feed from remote
 	feedReq, _ := http.NewRequest("GET", f.url, nil)
 	feedReq.SetBasicAuth(f.username, f.password)
+	if (f.agent != "") {
+		feedReq.Header.Set("User-Agent", f.agent)
+	}
 	feedResp, _ := client.Do(feedReq)
 	defer feedResp.Body.Close()
 	// copy headers
@@ -123,11 +128,16 @@ func main() {
 		feed, _ := config.String(section, "feed")
 		username, _ := config.String(section, "username")
 		password, _ := config.String(section, "password")
+		agent, err := config.String(section, "user-agent")
+		if (err != nil) {
+			agent, _ = config.String("", "user-agent")
+		}
 		newFeed = NewFeed(
 			section,
 			feed,
 			username,
 			password,
+			agent,
 		)
 		filterField, _ := config.String(section, "filter-field")
 		if filterField != "" {


### PR DESCRIPTION
Had some problems with a few feeds. This PR:

  * Allows changing the "User-Agent" header
  * Sends basic auth only if a username is supplied
  * Gives some additional output when feeds can't be parsed